### PR TITLE
Moved from cifar10 to mock_32x32 dataset

### DIFF
--- a/tests/data/configs/hawq/inception_v3_cifar10_mixed_int.json
+++ b/tests/data/configs/hawq/inception_v3_cifar10_mixed_int.json
@@ -1,6 +1,5 @@
 {
     "model": "inception_v3",
-    "dataset": "CIFAR10",
     "input_info": {
         "sample_size": [
             2,

--- a/tests/data/configs/hawq/resnet18_cifar10_mixed_int.json
+++ b/tests/data/configs/hawq/resnet18_cifar10_mixed_int.json
@@ -1,6 +1,5 @@
 {
     "model": "resnet18",
-    "dataset": "CIFAR10",
     "input_info": {
         "sample_size": [
             2,


### PR DESCRIPTION
Also encapsulated spy-specific validations into `setup_spy` and `validate_spy` methods.
Currently, AutoQ test cases are without HAWQ specific mocks (e.g. set_chosen_config) and don't check anything - just run samples.
@vuiseng9 